### PR TITLE
Check if it's a secret before de/encode

### DIFF
--- a/kube-secret-editor.py
+++ b/kube-secret-editor.py
@@ -41,18 +41,20 @@ def repr_str(dumper, data):
 
 
 def decode(secret):
-    secret['data'] = {
-        k: base64.b64decode(v).decode('utf8')
-        for k, v in secret['data'].items()
-    }
+    if 'data' in secret:
+        secret['data'] = {
+            k: base64.b64decode(v).decode('utf8')
+            for k, v in secret['data'].items()
+        }
     return secret
 
 
 def encode(secret):
-    secret['data'] = {
-        k: base64.b64encode(v.encode())
-        for k, v in secret['data'].items()
-    }
+    if 'data' in secret:
+        secret['data'] = {
+            k: base64.b64encode(v.encode())
+            for k, v in secret['data'].items()
+        }
     return secret
 
 


### PR DESCRIPTION
By checking if the yaml contains a data field, I check whether we need to decode and encode, and thus we can set KUBE_EDITOR all the time for any resource